### PR TITLE
chore: Fix list of adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/porscheofficial/cookie-consent-banner/main/LICENSE.md)
 [![npm](https://img.shields.io/npm/dm/@porscheofficial/cookie-consent-banner.svg)](https://www.npmjs.com/package/@porscheofficial/cookie-consent-banner)
 
-👉 _See the component in action on the websites of the following projects: [**Cyklær**](https://www.cyklaer.de), [**SOUNCE**](https://www.sounce.io) and [**VIN-Art**](https://www.vinart.digital/?s=ccb)._ 👈
+👉 _See the component in action on the websites of the following projects: [**Cyklær**](https://www.cyklaer.de), [**Simutrack**](https://www.simutrack.de/) and [**VIN-Art**](https://www.vinart.digital/?s=ccb)._ 👈
 
 </div>
   


### PR DESCRIPTION
Remove Sounce. Sounce is now part of MHP (https://www.mhp.com/de/services/digital-services/sounce) and uses Usercentrics Consent Management. Add [Simutrack](https://www.simutrack.de/) to list of adopters instead.

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `/CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [X] I have read and accept the [Contributor License Agreement](https://github.com/porscheofficial/cookie-consent-banner/blob/cd4e241b0929042c3a6592f023ec1dac485e9d22/CONTRIBUTOR_LICENSE_AGREEMENT.md)
