### PR TITLE
✨ feat(cookie-consent-banner): introduce ::part pseudo selector

### DIFF
--- a/packages/cookie-consent-banner-react/README.md
+++ b/packages/cookie-consent-banner-react/README.md
@@ -113,7 +113,11 @@ triggerCookieConsentBanner({ showDetails: true });
 
 ### Styling
 
-The appearance of the component can be influenced by updating the available CSS Properties.
+Styling can be done in two different ways: Either via the availabe CSS Properties or via the [CSS `::part` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::part).
+
+#### Styling with CSS Properties
+
+The appearance of the component can be influenced by updating the availabe CSS Properties. In most cases this is enough customization flexibility but since not every aspect is exposed, you might want to use the [`::part` selectors](#styling-with-the-part-selectors) if you need more flexibility.
 
 ```html
 <style>
@@ -151,6 +155,38 @@ The appearance of the component can be influenced by updating the available CSS 
     --cookie-consent-banner-font-size-headline: 1.5rem;
     --cookie-consent-banner-font-family-body: inherit;
     --cookie-consent-banner-font-size-body: 0.875rem;
+  }
+</style>
+```
+
+#### Styling with the `::part` selectors
+
+For full control over the styles we provide you these CSS parts to customize completely by your own:
+
+1. `cookie-consent-banner::part(primary-button)` for styling the primary button
+2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
+3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
+4. `cookie-consent-banner::part(description)` for styling the description texts
+5. `cookie-consent-banner::part(headline)` for styling the headline
+
+```html
+<style>
+  cookie-consent-banner::part(primary-button) {
+    text-transform: uppercase;
+  }
+
+  cookie-consent-banner::part(secondary-button) {
+    text-transform: uppercase;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  }
+
+  cookie-consent-banner::part(checkbox) {
+    accent-color: rgb(24, 251, 107);
+  }
+
+  cookie-consent-banner::part(description),
+  cookie-consent-banner::part(headline) {
+    font-family: "Arial", sans-serif;
   }
 </style>
 ```

--- a/packages/cookie-consent-banner-react/README.md
+++ b/packages/cookie-consent-banner-react/README.md
@@ -166,8 +166,9 @@ For full control over the styles we provide you these CSS parts to customize com
 1. `cookie-consent-banner::part(primary-button)` for styling the primary button
 2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
 3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
-4. `cookie-consent-banner::part(description)` for styling the description texts
-5. `cookie-consent-banner::part(headline)` for styling the headline
+4. `cookie-consent-banner::part(description-main)` for styling the main description text
+5. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
+6. `cookie-consent-banner::part(headline)` for styling the headline
 
 ```html
 <style>

--- a/packages/cookie-consent-banner-react/README.md
+++ b/packages/cookie-consent-banner-react/README.md
@@ -163,12 +163,13 @@ The appearance of the component can be influenced by updating the availabe CSS P
 
 For full control over the styles we provide you these CSS parts to customize completely by your own:
 
-1. `cookie-consent-banner::part(primary-button)` for styling the primary button
-2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
-3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
-4. `cookie-consent-banner::part(description-main)` for styling the main description text
-5. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
-6. `cookie-consent-banner::part(headline)` for styling the headline
+1. `cookie-consent-banner::part(button-accept-all)` for styling the primary button which triggers "Accept All Cookies"
+2. `cookie-consent-banner::part(button-persist-selection)` for styling the secondary button which triggers "Save Selection"
+3. `cookie-consent-banner::part(button-essential-only)` for styling the secondary button which triggers "Only required Cookies"
+4. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
+5. `cookie-consent-banner::part(description-main)` for styling the main description text
+6. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
+7. `cookie-consent-banner::part(headline)` for styling the headline
 
 ```html
 <style>

--- a/packages/cookie-consent-banner/README.md
+++ b/packages/cookie-consent-banner/README.md
@@ -144,8 +144,9 @@ For full control over the styles we provide you these CSS parts to customize com
 1. `cookie-consent-banner::part(primary-button)` for styling the primary button
 2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
 3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
-4. `cookie-consent-banner::part(description)` for styling the description texts
-5. `cookie-consent-banner::part(headline)` for styling the headline
+4. `cookie-consent-banner::part(description-main)` for styling the main description text
+5. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
+6. `cookie-consent-banner::part(headline)` for styling the headline
 
 ```html
 <style>

--- a/packages/cookie-consent-banner/README.md
+++ b/packages/cookie-consent-banner/README.md
@@ -91,7 +91,11 @@ In order to allow the user to always update its preferences it's possible to tri
 
 ### Styling
 
-The appearance of the component can be influenced by updating the availabe CSS Properties.
+Styling can be done in two different ways: Either via the availabe CSS Properties or via the [CSS `::part` pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::part).
+
+#### Styling with CSS Properties
+
+The appearance of the component can be influenced by updating the availabe CSS Properties. In most cases this is enough customization flexibility but since not every aspect is exposed, you might want to use the [`::part` selectors](#styling-with-the-part-selectors) if you need more flexibility.
 
 ```html
 <style>
@@ -129,6 +133,38 @@ The appearance of the component can be influenced by updating the availabe CSS P
     --cookie-consent-banner-font-size-headline: 1.5rem;
     --cookie-consent-banner-font-family-body: inherit;
     --cookie-consent-banner-font-size-body: 0.875rem;
+  }
+</style>
+```
+
+#### Styling with the `::part` selectors
+
+For full control over the styles we provide you these CSS parts to customize completely by your own:
+
+1. `cookie-consent-banner::part(primary-button)` for styling the primary button
+2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
+3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
+4. `cookie-consent-banner::part(description)` for styling the description texts
+5. `cookie-consent-banner::part(headline)` for styling the headline
+
+```html
+<style>
+  cookie-consent-banner::part(primary-button) {
+    text-transform: uppercase;
+  }
+
+  cookie-consent-banner::part(secondary-button) {
+    text-transform: uppercase;
+    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  }
+
+  cookie-consent-banner::part(checkbox) {
+    accent-color: rgb(24, 251, 107);
+  }
+
+  cookie-consent-banner::part(description),
+  cookie-consent-banner::part(headline) {
+    font-family: "Arial", sans-serif;
   }
 </style>
 ```

--- a/packages/cookie-consent-banner/README.md
+++ b/packages/cookie-consent-banner/README.md
@@ -141,12 +141,13 @@ The appearance of the component can be influenced by updating the availabe CSS P
 
 For full control over the styles we provide you these CSS parts to customize completely by your own:
 
-1. `cookie-consent-banner::part(primary-button)` for styling the primary button
-2. `cookie-consent-banner::part(secondary-button)` for styling the secondary button
-3. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
-4. `cookie-consent-banner::part(description-main)` for styling the main description text
-5. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
-6. `cookie-consent-banner::part(headline)` for styling the headline
+1. `cookie-consent-banner::part(button-accept-all)` for styling the primary button which triggers "Accept All Cookies"
+2. `cookie-consent-banner::part(button-persist-selection)` for styling the secondary button which triggers "Save Selection"
+3. `cookie-consent-banner::part(button-essential-only)` for styling the secondary button which triggers "Only required Cookies"
+4. `cookie-consent-banner::part(checkbox)` for styling the checkboxes
+5. `cookie-consent-banner::part(description-main)` for styling the main description text
+6. `cookie-consent-banner::part(description-settings)` for styling the description text on the expanded settings
+7. `cookie-consent-banner::part(headline)` for styling the headline
 
 ```html
 <style>

--- a/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
+++ b/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
@@ -217,7 +217,9 @@ export class CookieConsentBanner {
           tabIndex={-1}
         >
           {Boolean(this.headline) && (
-            <h1 class="cc_headline" part="headline">{this.headline}</h1>
+            <h1 class="cc_headline" part="headline">
+              {this.headline}
+            </h1>
           )}
           <form>
             <p class="cc_text" part="description">

--- a/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
+++ b/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
@@ -222,12 +222,12 @@ export class CookieConsentBanner {
             </h1>
           )}
           <form>
-            <p class="cc_text" part="description">
+            <p class="cc_text" part="description-main">
               <slot />
             </p>
             {Boolean(this.isShownSettings) && (
               <div class="cc_settings">
-                <p part="description" class="cc_settings_description">
+                <p part="description-settings" class="cc_settings_description">
                   {this.contentSettingsDescription}
                 </p>
                 <div class="cc_checkboxes">

--- a/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
+++ b/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
@@ -273,7 +273,7 @@ export class CookieConsentBanner {
             <div class="cc_buttons">
               {Boolean(this.isShownSettings) && (
                 <button
-                  part="secondary-button"
+                  part="button-persist-selection"
                   type="submit"
                   class="secondary"
                   onClick={() => this.persistSelection()}
@@ -285,7 +285,7 @@ export class CookieConsentBanner {
               {!this.isShownSettings &&
                 !!this.btnLabelOnlyEssentialAndContinue && (
                   <button
-                    part="secondary-button"
+                    part="button-essential-only"
                     class="secondary"
                     type="button"
                     onClick={() => this.handleEssentialsOnly()}
@@ -295,7 +295,7 @@ export class CookieConsentBanner {
                   </button>
                 )}
               <button
-                part="primary-button"
+                part="button-accept-all"
                 onClick={() => this.handleAcceptAll()}
                 onKeyPress={() => this.handleAcceptAll()}
                 type="button"

--- a/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
+++ b/packages/cookie-consent-banner/src/components/cookie-consent-banner/cookie-consent-banner.tsx
@@ -217,24 +217,26 @@ export class CookieConsentBanner {
           tabIndex={-1}
         >
           {Boolean(this.headline) && (
-            <h1 class="cc_headline">{this.headline}</h1>
+            <h1 class="cc_headline" part="headline">{this.headline}</h1>
           )}
           <form>
-            <p class="cc_text">
+            <p class="cc_text" part="description">
               <slot />
             </p>
             {Boolean(this.isShownSettings) && (
               <div class="cc_settings">
-                <p class="cc_settings_description">
+                <p part="description" class="cc_settings_description">
                   {this.contentSettingsDescription}
                 </p>
                 <div class="cc_checkboxes">
                   {this.availableCategories.map((category) => (
                     <label
+                      part="checkbox-label"
                       class="cc_checkboxes_item"
                       htmlFor={`check-category-${category.label}`}
                     >
                       <input
+                        part="checkbox"
                         id={`check-category-${category.label}`}
                         type="checkbox"
                         disabled={category.isMandatory ?? false}
@@ -269,6 +271,7 @@ export class CookieConsentBanner {
             <div class="cc_buttons">
               {Boolean(this.isShownSettings) && (
                 <button
+                  part="secondary-button"
                   type="submit"
                   class="secondary"
                   onClick={() => this.persistSelection()}
@@ -280,6 +283,7 @@ export class CookieConsentBanner {
               {!this.isShownSettings &&
                 !!this.btnLabelOnlyEssentialAndContinue && (
                   <button
+                    part="secondary-button"
                     class="secondary"
                     type="button"
                     onClick={() => this.handleEssentialsOnly()}
@@ -289,6 +293,7 @@ export class CookieConsentBanner {
                   </button>
                 )}
               <button
+                part="primary-button"
                 onClick={() => this.handleAcceptAll()}
                 onKeyPress={() => this.handleAcceptAll()}
                 type="button"

--- a/packages/cookie-consent-banner/src/index.html
+++ b/packages/cookie-consent-banner/src/index.html
@@ -50,9 +50,14 @@
         accent-color: rgb(24, 251, 107);
       }
 
-      cookie-consent-banner::part(description),
+      cookie-consent-banner::part(description-main),
+      cookie-consent-banner::part(description-settings),
       cookie-consent-banner::part(headline) {
         font-family: "Arial", sans-serif;
+      }
+
+      cookie-consent-banner::part(description-settings) {
+        color: rgba(255, 255, 255, 0.66);
       }
     </style>
   </head>

--- a/packages/cookie-consent-banner/src/index.html
+++ b/packages/cookie-consent-banner/src/index.html
@@ -31,6 +31,28 @@
         --cookie-consent-banner-spacings-container-padding-left: 0;
         --cookie-consent-banner-spacings-container-padding-bottom: 0;
         --cookie-consent-banner-spacings-container-padding-right: 0;
+
+        --cookie-consent-banner-colors-primary: rgb(24, 77, 251);
+        --cookie-consent-banner-colors-primary-border: rgb(24, 77, 251);
+      }
+
+      /* Check if CSS Parts are merged with default styles and CSS variable overrides */
+      cookie-consent-banner::part(primary-button) {
+        text-transform: uppercase;
+      }
+
+      cookie-consent-banner::part(secondary-button) {
+        text-transform: uppercase;
+        box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+      }
+
+      cookie-consent-banner::part(checkbox) {
+        accent-color: rgb(24, 251, 107);
+      }
+
+      cookie-consent-banner::part(description),
+      cookie-consent-banner::part(headline) {
+        font-family: "Arial", sans-serif;
       }
     </style>
   </head>
@@ -77,6 +99,13 @@
             "Enable us to determine how visitors interact with our service in order to improve the user experience.",
           key: "analytics",
           label: "Analysis cookies",
+        },
+        {
+          description:
+            "These Cookies are required for the page to work properly and won't track you",
+          key: "technically-required",
+          label: "Technically required",
+          isMandatory: true,
         },
       ];
     </script>

--- a/packages/cookie-consent-banner/src/index.html
+++ b/packages/cookie-consent-banner/src/index.html
@@ -37,11 +37,12 @@
       }
 
       /* Check if CSS Parts are merged with default styles and CSS variable overrides */
-      cookie-consent-banner::part(primary-button) {
+      cookie-consent-banner::part(button-accept-all) {
         text-transform: uppercase;
       }
 
-      cookie-consent-banner::part(secondary-button) {
+      cookie-consent-banner::part(button-persist-selection),
+      cookie-consent-banner::part(button-essential-only) {
         text-transform: uppercase;
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
       }


### PR DESCRIPTION
This PR adds the possibility to style parts of the web component using the CSS `::part` selector. Thereby we can provide nice looking defaults and for customization either via the easy-to-use CSS variable solution or via the fully flexible `::part()` API.

### Pull Request Checklist

<!-- Make sure to read and accept the CLA, before you open the pull request: `/CONTRIBUTOR_LICENSE_AGREEMENT` -->
<!-- Tick the checkbox in case you accept it (`[x]`) -->

- [x] I have read and accept the [Contributor License Agreement](https://github.com/porscheofficial/cookie-consent-banner/blob/cd4e241b0929042c3a6592f023ec1dac485e9d22/CONTRIBUTOR_LICENSE_AGREEMENT.md)
